### PR TITLE
Refactor addon and use /config

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn
       - run: yarn publish --access public

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,30 @@
-FROM node:lts-alpine
+ARG NODE_VERSION="16"
+ARG BASE_IMAGE="node:${NODE_VERSION}-alpine"
 
-WORKDIR /usr/src/app
+FROM ${BASE_IMAGE} AS build
 
-COPY package.json ./
-COPY tsconfig.json ./
-COPY yarn.lock ./
-COPY src/** ./
-COPY . .
+WORKDIR /workspace
+
+COPY package.json yarn.lock ./
+
 RUN yarn install
-RUN yarn build
 
-CMD [ "node", "./dist/main.js" ]
+COPY . ./
+
+RUN yarn run build
+
+
+FROM scratch AS rootfs
+
+COPY --from=build /workspace/dist /dist
+
+COPY --from=build /workspace/config-sample.json /dist/
+
+
+FROM ${BASE_IMAGE}
+
+WORKDIR /data
+
+COPY --from=rootfs / /
+
+CMD [ "node", "/dist/main.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,17 @@ RUN yarn install
 
 COPY . ./
 
-RUN yarn run build
+RUN yarn run build \
+    && yarn install --production
 
 
 FROM scratch AS rootfs
 
-COPY --from=build /workspace/dist /dist
+COPY --from=build /workspace/node_modules /app/node_modules
 
-COPY --from=build /workspace/config-sample.json /dist/
+COPY --from=build /workspace/dist /app/dist
+
+COPY --from=build /workspace/config-sample.json /app/
 
 
 FROM ${BASE_IMAGE}
@@ -27,4 +30,4 @@ WORKDIR /data
 
 COPY --from=rootfs / /
 
-CMD [ "node", "/dist/main.js" ]
+CMD [ "node", "/app/dist/main.js" ]

--- a/risco-mqtt-local-addon/DOCS.md
+++ b/risco-mqtt-local-addon/DOCS.md
@@ -1,0 +1,12 @@
+# Risco MQTT Addon
+
+## Configuration
+
+The addon cannot be configured from the addon configuration page. In order to configure the addon, you need to add/edit the `/config/risco-mqtt.json` file and restart the addon.
+
+For editing the configuration file, the [Studio Code Server](https://github.com/hassio-addons/addon-vscode#readme) addon.
+
+## Building from source
+
+The addon just extends the risco-mqtt docker image. Therefore, if you make changes to the
+source code of the risco-mqtt (and not the addon itself), you will need to rebuilt the risco-mqtt image.

--- a/risco-mqtt-local-addon/Dockerfile
+++ b/risco-mqtt-local-addon/Dockerfile
@@ -1,13 +1,3 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM vanackej/risco-mqtt-local:latest
 
-RUN apk add --no-cache nodejs npm
-RUN npm install -g npx
-RUN npm install -g @vanackej/risco-mqtt-local@0.3.3
-
-WORKDIR /data
-
-COPY run.sh /
-RUN chmod a+x /run.sh
-
-CMD [ "/run.sh" ]
+ENV RISCO_MQTT_HA_CONFIG_FILE="/config/risco-mqtt.json"

--- a/risco-mqtt-local-addon/build.yaml
+++ b/risco-mqtt-local-addon/build.yaml
@@ -1,7 +1,0 @@
----
-build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:11.0.1
-  amd64: ghcr.io/hassio-addons/base/amd64:11.0.1
-  armhf: ghcr.io/hassio-addons/base/armhf:11.0.1
-  armv7: ghcr.io/hassio-addons/base/armv7:11.0.1
-  i386: ghcr.io/hassio-addons/base/i386:11.0.1

--- a/risco-mqtt-local-addon/config.yaml
+++ b/risco-mqtt-local-addon/config.yaml
@@ -9,20 +9,9 @@ arch:
   - armhf
   - armv7
   - i386
-host_network: true
 ports:
   33000/tcp: 33000
 ports_description:
   33000/tcp: Socket server for proxy mode
-options:
-  log: info
-  logColorize: false
-  ha_discovery_include_nodeId: false
-  panel:
-    panelIp: str
-schema:
-  log: list(trace|debug|info|notice|warning|error|fatal)?
-  logColorize: bool?
-  ha_discovery_include_nodeId: bool?
-  panel:
-    panelIp: str
+map:
+  - config:rw

--- a/risco-mqtt-local-addon/run.sh
+++ b/risco-mqtt-local-addon/run.sh
@@ -1,7 +1,0 @@
-#! /bin/sh
-echo "Current dir is ${pwd}"
-ls
-cat options.json
-cp options.json config.json
-cat /data/config.json
-npx @vanackej/risco-mqtt-local

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,18 @@ const path = require('path');
 import {riscoMqttHomeAssistant} from './lib';
 
 try {
-    const configPath = path.join(process.cwd(), 'config.json')
+    let configPath = ""
+    if ("RISCO_MQTT_HA_CONFIG_FILE" in process.env) {
+        // if this var is set, we know we are running in the addon
+        configPath = process.env.RISCO_MQTT_HA_CONFIG_FILE
+        // check if is file
+        const sampleConfigPath = path.join(__dirname, "config-sample.json")
+        if (!fs.existsSync(configPath) && fs.existsSync(sampleConfigPath)) {
+            fs.copyFileSync(sampleConfigPath, configPath);
+        }
+    } else {
+        configPath = path.join(process.cwd(), 'config.json')
+    }
     console.log('Loading config from: ' + configPath)
     if (fs.existsSync(configPath)) {
         const config = require(configPath)

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ try {
         // if this var is set, we know we are running in the addon
         configPath = process.env.RISCO_MQTT_HA_CONFIG_FILE
         // check if is file
-        const sampleConfigPath = path.join(__dirname, "config-sample.json")
+        const sampleConfigPath = path.join(__dirname, "../config-sample.json")
         if (!fs.existsSync(configPath) && fs.existsSync(sampleConfigPath)) {
             fs.copyFileSync(sampleConfigPath, configPath);
         }


### PR DESCRIPTION
If the addon configuration does not provide you enough options, just use your own. There is no shame in that.

Refs https://github.com/vanackej/risco-mqtt-local/issues/1